### PR TITLE
Fixes for MacOS support

### DIFF
--- a/cpp/include/calibration.hpp
+++ b/cpp/include/calibration.hpp
@@ -4093,7 +4093,9 @@ static inline std::string getRootHiddenDir() {
     std::string filename(snfile_path);
     filename += "\\Stereolabs\\";
 #elif __APPLE__
-    std::string filename = "~/Library/ZED/";
+    std::string homeDir (std::getenv("HOME"));
+    std::string appendix ("/Library/Application Support/ZED/");
+    std::string filename = homeDir + appendix;
 #else //LINUX
     std::string filename = "/usr/local/zed/";
 #endif
@@ -4120,14 +4122,14 @@ bool downloadCalibrationFile(unsigned int serial_number, std::string &calibratio
     calibration_file = path + specific_name;
     if (!checkFile(calibration_file)) {
         // Download the file
-        std::string url("'http://calib.stereolabs.com/?SN=");
+        std::string url("http://calib.stereolabs.com/?SN=");
         std::string cmd;
-        cmd = "mkdir -p " + path + " && wget " + url + std::to_string(serial_number) + "' -O " + calibration_file;
+        cmd = "mkdir -p \"" + path + "\" && wget \"" + url + std::to_string(serial_number) + "\" -O \"" + calibration_file + "\"";
         std::cout << cmd << std::endl;
         system(cmd.c_str());
 
         if (!checkFile(calibration_file)) {
-            std::cout << "Invalid calibration file" << std::endl;
+            std::cout << "Invalid calibration file " << calibration_file << std::endl;
             return 1;
         }
     }

--- a/cpp/include/calibration.hpp
+++ b/cpp/include/calibration.hpp
@@ -18,7 +18,11 @@
 #pragma comment(lib, "urlmon.lib")
 #else
 #include <unistd.h>
-#include <sys/vfs.h>
+#ifdef __APPLE__
+#include<sys/mount.h>
+#else
+#include<sys/vfs.h>
+#endif
 #endif
 
 

--- a/cpp/include/calibration.hpp
+++ b/cpp/include/calibration.hpp
@@ -4092,7 +4092,8 @@ static inline std::string getRootHiddenDir() {
 
     std::string filename(snfile_path);
     filename += "\\Stereolabs\\";
-
+#elif __APPLE__
+    std::string filename = "~/Library/ZED/";
 #else //LINUX
     std::string filename = "/usr/local/zed/";
 #endif
@@ -4121,7 +4122,7 @@ bool downloadCalibrationFile(unsigned int serial_number, std::string &calibratio
         // Download the file
         std::string url("'http://calib.stereolabs.com/?SN=");
         std::string cmd;
-        cmd = "wget " + url + std::to_string(serial_number) + "' -O " + calibration_file;
+        cmd = "mkdir -p " + path + " && wget " + url + std::to_string(serial_number) + "' -O " + calibration_file;
         std::cout << cmd << std::endl;
         system(cmd.c_str());
 


### PR DESCRIPTION
On Apple systems to be able to compile it is necessary to replace the vfs import

```c
#include<sys/vfs.h>
```

with an import to `mount.h`:

```c
#include<sys/mount.h>
```

I have added a compiler macro to use the one which is needed on the current system (as done [here](https://github.com/kartverket/fyba/pull/18)).

Also the linux path will not work under MacOS because all the root directories are not accessible by the user. I have changed it to a path in the user home directory and added fixes to create the directory and support spaces in paths.