### PR TITLE
fixed read 'stereo:ty' and 'stereo:tz' doesn't need resolution_str

### DIFF
--- a/cpp/include/calibration.hpp
+++ b/cpp/include/calibration.hpp
@@ -4206,8 +4206,8 @@ bool initCalibration(std::string calibration_file, cv::Size2i image_size, cv::Ma
     // Get translations
     float T_[3];
     T_[0] = camerareader.getValue("stereo:baseline", 0.0f);
-    T_[1] = camerareader.getValue("stereo:ty_" + resolution_str, 0.f);
-    T_[2] = camerareader.getValue("stereo:tz_" + resolution_str, 0.f);
+    T_[1] = camerareader.getValue("stereo:ty", 0.f);
+    T_[2] = camerareader.getValue("stereo:tz", 0.f);
 
     // Get left parameters
     float left_cam_cx = camerareader.getValue("left_cam_" + resolution_str + ":cx", 0.0f);

--- a/python/zed_opencv_native.py
+++ b/python/zed_opencv_native.py
@@ -71,8 +71,8 @@ def init_calibration(calibration_file, image_size) :
         check_data = False
 
     T_ = np.array([-float(config['STEREO']['Baseline'] if 'Baseline' in config['STEREO'] else 0),
-                   float(config['STEREO']['TY_'+resolution_str] if 'TY_'+resolution_str in config['STEREO'] else 0),
-                   float(config['STEREO']['TZ_'+resolution_str] if 'TZ_'+resolution_str in config['STEREO'] else 0)])
+                   float(config['STEREO']['TY'] if 'TY' in config['STEREO'] else 0),
+                   float(config['STEREO']['TZ'] if 'TZ' in config['STEREO'] else 0)])
 
 
     left_cam_cx = float(config['LEFT_CAM_'+resolution_str]['cx'] if 'cx' in config['LEFT_CAM_'+resolution_str] else 0)


### PR DESCRIPTION
zed `SN*.conf` file `STEREO` node `TY` and `TZ` doesn't contains resolution now .
```
[STEREO]
Baseline=62.8212
TY=-0.0812117
TZ=-0.0304459
CV_2K=0.00995881
CV_FHD=0.00995881
CV_HD=0.00995881
CV_VGA=0.00995881
```
